### PR TITLE
Fix escaped quotes in string ending the string early.

### DIFF
--- a/peep/lexer.py
+++ b/peep/lexer.py
@@ -129,7 +129,7 @@ class Lexer(object):
             escape_characters = {'n': '\n', 't': '\t', 'v': '\v', 'b': '\b', 'f': '\f', 'a': '\a', '\\': '\\',
                                  '"': '\"', '\'': '\''}
             
-            str = ""
+            string_literal = ""
             # consume '"'
             self._next_ch()
             prev = self.current
@@ -144,14 +144,14 @@ class Lexer(object):
                     # current is the escaped character, advance by one
                     self._next_ch()
                 else:
-                    str += prev
+                    string_literal += prev
                     is_escaped = self.current == "\\"
                 
                 prev = self.current
             if prev is not None:
-                str += prev
+                string_literal += prev
 
-            return self._make_token(TokenTag.STR_LITERAL, str)
+            return self._make_token(TokenTag.STR_LITERAL, string_literal)
 
         raise_error(LexError("Unknown token {}".format(self.current), lineno))
 

--- a/peep/lexer.py
+++ b/peep/lexer.py
@@ -126,34 +126,30 @@ class Lexer(object):
             return Token(TokenTag.REL_OP, '>', lineno)
 
         if self.current == '"':
-            str = ""
-
-            # consume '"'
-            self._next_ch()
-
-            while self.current is not None and self.current != '"':
-                str += self.current
-                self._next_ch()
-
-            # handle escape sequences
-            s = str
-            prev = None
-            str = ""
             escape_characters = {'n': '\n', 't': '\t', 'v': '\v', 'b': '\b', 'f': '\f', 'a': '\a', '\\': '\\',
                                  '"': '\"', '\'': '\''}
-            for ch in s:
-                if prev is None:
-                    prev = ch
-                elif prev == '\\':
-                    prev = None
-                    str += escape_characters.get(ch, '\\' + ch)
+            
+            str = ""
+            # consume '"'
+            self._next_ch()
+            prev = self.current
+            is_escaped = prev == '\\'
+            
+            while self.current is not None and (self.current != '"' or is_escaped):
+                self._next_ch()
+                # handle escape sequences
+                if is_escaped:
+                    str += escape_characters.get(self.current, '\\' + self.current)
+                    is_escaped = False
+                    # current is the escaped character, advance by one
+                    self._next_ch()
                 else:
                     str += prev
-                    prev = ch
+                    is_escaped = self.current == "\\"
+                
+                prev = self.current
             if prev is not None:
                 str += prev
-
-            return self._make_token(TokenTag.STR_LITERAL, str)
 
             return self._make_token(TokenTag.STR_LITERAL, str)
 

--- a/peep/lexer.py
+++ b/peep/lexer.py
@@ -8,27 +8,27 @@ class Lexer(object):
     def __init__(self, file):
         self.prgm = file.read()
         self.prgm_len = len(self.prgm)
-        
+
         if self.prgm_len == 0:
             raise_error(LexError("The program is empty!", 0))
-        
+
         self.idx = 0
         self.current = self.prgm[self.idx]
         self.prev_tag = None # for detection of unary operators
         self.dct = {}
         self._init_dict()
-    
+
     def next_token(self):
         if self.current is None:
             return Token(TokenTag.EOF, None, lineno)
-        
+
         if self.current.isspace():
             self._eat_whitespace()
             return self.next_token()
-        
+
         if self.current == '/':
             peek = self._peek()
-            
+
             if peek is not None:
                 if peek == '/':
                     self._eat_comment()
@@ -36,204 +36,183 @@ class Lexer(object):
                 elif peek == '*':
                     self._eat_multiline_comment()
                     return self.next_token()
-        
+
         if self.current.isdigit():
             return self._make_num_tok()
-        
+
         if self.current.isalpha():
             return self._make_word_tok()
-        
+
         if self.current == '(':
             return self._make_token(TokenTag.LPAREN, '(')
-        
+
         if self.current == ')':
             return self._make_token(TokenTag.RPAREN, ')')
-        
+
         if self.current == '{':
             return self._make_token(TokenTag.LBRACK, '{')
-        
+
         if self.current == '}':
             return self._make_token(TokenTag.RBRACK, '}')
-        
+
         if self.current == ';':
             return self._make_token(TokenTag.SEMICOLON, ';')
-        
+
         if self.current == '=':
             self._next_ch()
-            
+
             if self.current is not None and self.current == '=':
                 return self._make_token(TokenTag.EQ_OP, '==')
-            
+
             self.prev_tag = TokenTag.ASSIGN
             return Token(TokenTag.ASSIGN, '=', lineno)
-        
-        if self.current in ['+', '-', '*', '/', '%']:
+
+        if self.current in ('+', '-', '*', '/', '%'):
             op = self.current
             peek = self._peek()
-            
-            if (peek is not None and
-                op in ['+', '-'] and
-                (peek == '(' or peek.isalnum()) and
-                self.prev_tag in [None, TokenTag.ASSIGN, TokenTag.LPAREN, TokenTag.REL_OP, TokenTag.ADD_OP, TokenTag.MUL_OP]):
-                return self._make_token(TokenTag.UNARY_OP, op)
-            
-            if (peek is not None and
-                op in ['+', '-'] and
-                peek == '='):
-                return self._make_token(TokenTag.PLUS_EQ if op == '+' else TokenTag.MINUS_EQ, op + '=', True)
-            
-            if op in ['+', '-']:
+
+            if op in ("+", "-"):
+                if (peek is not None and
+                    (peek == '(' or peek.isalnum()) and
+                    self.prev_tag in [None, TokenTag.ASSIGN, TokenTag.LPAREN, TokenTag.REL_OP, TokenTag.ADD_OP, TokenTag.MUL_OP]):
+                    return self._make_token(TokenTag.UNARY_OP, op)
+
+                if peek == "=":
+                    return self._make_token(TokenTag.PLUS_EQ if op == '+' else TokenTag.MINUS_EQ, op + '=', True)
+
                 return self._make_token(TokenTag.ADD_OP, op)
-            
+
             return self._make_token(TokenTag.MUL_OP, op)
-        
+
         if self.current == '!':
             self._next_ch()
-            
+
             if self.current is not None and self.current == '=':
                 return self._make_token(TokenTag.EQ_OP, '!=')
-            
+
             self.prev_tag = TokenTag.UNARY_OP
             return Token(TokenTag.UNARY_OP, '!', lineno)
-        
+
         if self.current == '&':
             peek = self._peek()
-            
+
             if peek is not None and peek == '&':
                 self._next_ch() # eat '&'
                 return self._make_token(TokenTag.AND, '&&')
-        
+
         if self.current == '|':
             peek = self._peek()
-            
+
             if peek is not None and peek == '|':
                 self._next_ch() # eat '|'
                 return self._make_token(TokenTag.OR, '||')
-        
+
         if self.current == '<':
             self._next_ch()
-            
+
             if self.current is not None and self.current == '=':
                 return self._make_token(TokenTag.REL_OP, '<=')
-            
+
             self.prev_tag = TokenTag.REL_OP
             return Token(TokenTag.REL_OP, '<', lineno)
-        
+
         if self.current == '>':
             self._next_ch()
-            
+
             if self.current is not None and self.current == '=':
                 return self._make_token(TokenTag.REL_OP, '>=')
-            
+
             self.prev_tag = TokenTag.REL_OP
             return Token(TokenTag.REL_OP, '>', lineno)
-        
+
         if self.current == '"':
             str = ""
-            
+
             # consume '"'
             self._next_ch()
-            
+
             while self.current is not None and self.current != '"':
                 str += self.current
                 self._next_ch()
-            
+
             # handle escape sequences
             s = str
             prev = None
             str = ""
-            
-            for i in range(len(s)):
+
+            for ch in s:
                 if prev is None:
-                    prev = s[i]
+                    prev = ch
                 elif prev == '\\':
-                    ch = s[i]
                     prev = None
-                    
-                    if ch == 'n':
-                        str += '\n'
-                    elif ch == 't':
-                        str += '\t'
-                    elif ch == 'v':
-                        str += '\v'
-                    elif ch == 'b':
-                        str += '\b'
-                    elif ch == 'f':
-                        str += '\f'
-                    elif ch == 'a':
-                        str += '\a'
-                    elif ch == '\\':
-                        str += '\\'
-                    elif ch == '"':
-                        str += '\"'
-                    elif ch == '\'':
-                        str += '\''
+                    if ch == '\\' or ch == '\'':
+                        str += ch
                     else: # unknown escape sequence
                         str += '\\' + ch
                 else:
                     str += prev
-                    prev = s[i]
-            
+                    prev = ch
+
             if prev is not None:
                 str += prev
-            
+
             return self._make_token(TokenTag.STR_LITERAL, str)
-        
+
         raise_error(LexError("Unknown token {}".format(self.current), lineno))
-    
+
     def _make_token(self, tag, lexeme, skip_twice=False):
         self._next_ch()
         if skip_twice:
             self._next_ch()
         self.prev_tag = tag
         return Token(tag, lexeme, lineno)
-    
+
     def _make_word_tok(self):
         word = ""
-        
+
         while self.current is not None and self.current.isalnum():
             word += self.current
             self._next_ch()
-        
+
         tag = self.dct.get(word)
-        
+
         if tag is not None:
             self.prev_tag = tag
             return Token(tag, word, lineno)
-        
+
         self.prev_tag = TokenTag.IDENT
         return Token(TokenTag.IDENT, word, lineno)
-    
+
     def _make_num_tok(self):
         num = ""
-        
+
         while self.current is not None and self.current.isdigit():
             num += self.current
             self._next_ch()
-        
+
         if self.current is not None and self.current == '.':
             num += self.current
             self._next_ch()
-            
+
             while self.current is not None and self.current.isdigit():
                 num += self.current
                 self._next_ch()
-            
+
             self.prev_tag = TokenTag.RL_CONST
             return Token(TokenTag.RL_CONST, num, lineno)
-        
+
         self.prev_tag = TokenTag.INT_CONST
         return Token(TokenTag.INT_CONST, num, lineno)
-    
+
     def _eat_multiline_comment(self):
         # consume "/*"
         self._next_ch()
         self._next_ch()
-        
+
         while True:
             while self.current is not None and self.current != '*':
                 self._next_ch()
-            
+
             if self.current is None:
                 raise_error(LexError("A multi-line comment doesn't end with '*/'!", lineno))
             elif self._peek() == '/':
@@ -244,32 +223,32 @@ class Lexer(object):
             else: # self._peek() != '/' (oops...)
                 self._next_ch()
                 # then continue the loop...
-    
+
     def _eat_comment(self):
         # consume "//"
         self._next_ch()
         self._next_ch()
-        
+
         while self.current != '\n':
             self._next_ch()
         # consume '\n'
         self._next_ch()
-    
+
     def _eat_whitespace(self):
         while self.current is not None and self.current.isspace():
             self._next_ch()
-    
+
     def _peek(self):
         next_idx = self.idx + 1
         return None if next_idx >= self.prgm_len else self.prgm[next_idx]
-    
+
     def _next_ch(self):
         if self.current == '\n':
             global lineno
             lineno += 1
         self.idx += 1
         self.current = None if self.idx >= self.prgm_len else self.prgm[self.idx]
-    
+
     def _init_dict(self):
         self.dct['int'] = TokenTag.INT
         self.dct['float'] = TokenTag.FLOAT

--- a/peep/lexer.py
+++ b/peep/lexer.py
@@ -139,22 +139,21 @@ class Lexer(object):
             s = str
             prev = None
             str = ""
-
+            escape_characters = {'n': '\n', 't': '\t', 'v': '\v', 'b': '\b', 'f': '\f', 'a': '\a', '\\': '\\',
+                                 '"': '\"', '\'': '\''}
             for ch in s:
                 if prev is None:
                     prev = ch
                 elif prev == '\\':
                     prev = None
-                    if ch == '\\' or ch == '\'':
-                        str += ch
-                    else: # unknown escape sequence
-                        str += '\\' + ch
+                    str += escape_characters.get(ch, '\\' + ch)
                 else:
                     str += prev
                     prev = ch
-
             if prev is not None:
                 str += prev
+
+            return self._make_token(TokenTag.STR_LITERAL, str)
 
             return self._make_token(TokenTag.STR_LITERAL, str)
 

--- a/peep/lexer.py
+++ b/peep/lexer.py
@@ -139,7 +139,7 @@ class Lexer(object):
                 self._next_ch()
                 # handle escape sequences
                 if is_escaped:
-                    str += escape_characters.get(self.current, '\\' + self.current)
+                    string_literal += escape_characters.get(self.current, '\\' + self.current)
                     is_escaped = False
                     # current is the escaped character, advance by one
                     self._next_ch()


### PR DESCRIPTION
The code for lexing a string literal was incorrect because it would ignore the fact that a quotation mark was escaped and skip parsing the rest of the string literal. I fixed this by not building an intermediate string, and instead building the string until we reach an unescaped quote. To make the escaped character code a bit cleaner, I opted to use a dictionary (for constant time lookup of escape codes, vs the linear time required for if statements). 

```
            # This ignores quotes that look like \"
            while self.current is not None and self.current != '"':
                str += self.current
                self._next_ch()
  ```