### PR TITLE
Handle XML specific characters (&, ", ', <, >) which need to be escaped.

### DIFF
--- a/peep/__main__.py
+++ b/peep/__main__.py
@@ -29,7 +29,7 @@ def main():
     group = parser.add_mutually_exclusive_group(required=True)
     
     # only one of the arguments below can be used
-    group.add_argument("-p", "--print-ast", help="Print AST (Abstract Syntax Tree) for the program in a seperate .xml file", action="store_true")
+    group.add_argument("-p", "--print_ast", help="Print AST (Abstract Syntax Tree) for the program in a seperate .xml file", action="store_true")
     group.add_argument("-i", help="Execute the program from the source file", action="store_true")
     
     parser.add_argument("file", type=str, help="file with a .peep extension")

--- a/peep/__main__.py
+++ b/peep/__main__.py
@@ -12,6 +12,8 @@ def p_ast(file):
     root = Parser(Lexer(file)).parse()
     astprinter = ASTPrinter(root)
     astprinter.print_ast()
+    import util
+    astprinter.write(util.filename)
 
 def i(file):
     root = Parser(Lexer(file)).parse()
@@ -27,7 +29,7 @@ def main():
     group = parser.add_mutually_exclusive_group(required=True)
     
     # only one of the arguments below can be used
-    group.add_argument("-p", "--print_ast", help="Print AST (Abstract Syntax Tree) for the program in a seperate .xml file", action="store_true")
+    group.add_argument("-p-ast", help="Print AST (Abstract Syntax Tree) for the program in a seperate .xml file", action="store_true")
     group.add_argument("-i", help="Execute the program from the source file", action="store_true")
     
     parser.add_argument("file", type=str, help="file with a .peep extension")
@@ -37,7 +39,6 @@ def main():
     
     from util import get_file
     fh = get_file(args.file)
-    
     if args.version:
         version()
     

--- a/peep/__main__.py
+++ b/peep/__main__.py
@@ -29,7 +29,7 @@ def main():
     group = parser.add_mutually_exclusive_group(required=True)
     
     # only one of the arguments below can be used
-    group.add_argument("-p-ast", help="Print AST (Abstract Syntax Tree) for the program in a seperate .xml file", action="store_true")
+    group.add_argument("-p", "--print-ast", help="Print AST (Abstract Syntax Tree) for the program in a seperate .xml file", action="store_true")
     group.add_argument("-i", help="Execute the program from the source file", action="store_true")
     
     parser.add_argument("file", type=str, help="file with a .peep extension")

--- a/peep/astprinter.py
+++ b/peep/astprinter.py
@@ -29,6 +29,9 @@ class ASTPrinter(TreeWalker):
 
     def visit_const(self, const):
         const_val = str(const.value).replace('"', "&quot;")
+        const_val = str(const_val).replace('<', "&lt;")
+        const_val = str(const_val).replace('>', "&gt;")
+
         self._file_writeline('<Constant type=\"{}\" value=\"{}\"></Constant>'.format(const.type, const_val))
 
     def visit_orop(self, orop):

--- a/peep/astprinter.py
+++ b/peep/astprinter.py
@@ -28,9 +28,27 @@ class ASTPrinter(TreeWalker):
         self._file_writeline('<Identifier type=\"{}\" name=\"{}\"></Identifier>'.format(ident.type, ident.value))
 
     def visit_const(self, const):
-        const_val = str(const.value).replace('"', "&quot;")
-        const_val = str(const_val).replace('<', "&lt;")
-        const_val = str(const_val).replace('>', "&gt;")
+        const_val = str(const.value)
+        if "&" in const_val:
+            possible_lone_amps = const_val.split("&")
+            print(const_val)
+            for index, sub_str in enumerate(possible_lone_amps):
+                if sub_str.startswith("quot;") or sub_str.startswith("lt;") or \
+                        sub_str.startswith("amp;") or sub_str.startswith("gt;"):
+                    possible_lone_amps[index] = "amp;" + sub_str
+
+                if index == 0:
+                    if possible_lone_amps[0] == "":
+                        possible_lone_amps[index] = "amp;" + sub_str
+                else:
+                    possible_lone_amps[index] = "amp;" + sub_str
+
+            const_val = "&".join(possible_lone_amps)
+
+        const_val = const_val.replace('<', "&lt;")
+        const_val = const_val.replace('>', "&gt;")
+        const_val = const_val.replace('"', "&quot;")
+        const_val = const_val.replace('\'', "&apos;")
 
         self._file_writeline('<Constant type=\"{}\" value=\"{}\"></Constant>'.format(const.type, const_val))
 

--- a/peep/astprinter.py
+++ b/peep/astprinter.py
@@ -31,7 +31,6 @@ class ASTPrinter(TreeWalker):
         const_val = str(const.value)
         if "&" in const_val:
             possible_lone_amps = const_val.split("&")
-            print(const_val)
             for index, sub_str in enumerate(possible_lone_amps):
                 if sub_str.startswith("quot;") or sub_str.startswith("lt;") or \
                         sub_str.startswith("amp;") or sub_str.startswith("gt;"):

--- a/peep/astprinter.py
+++ b/peep/astprinter.py
@@ -1,28 +1,36 @@
 from treewalker import TreeWalker
 
+
+class FileBuffer:
+    def __init__(self):
+        self.lines = []
+
+    def write(self, line):
+        self.lines.append(line)
+
+
 class ASTPrinter(TreeWalker):
     def __init__(self, tree):
         super().__init__()
         self.tree = tree
         self.indent = 0
         self.ind_inc = 2
-        
-        import util
-        self.file = open(util.filename + '.ast.xml', 'w')
-    
+        self.file = FileBuffer()
+
     def print_ast(self):
         if self.tree is None:
             return
-        
+
         self.file.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
         self.tree.accept(self)
-    
+
     def visit_ident(self, ident):
         self._file_writeline('<Identifier type=\"{}\" name=\"{}\"></Identifier>'.format(ident.type, ident.value))
-    
+
     def visit_const(self, const):
-        self._file_writeline('<Constant type=\"{}\" value=\"{}\"></Constant>'.format(const.type, const.value))
-    
+        const_val = str(const.value).replace('"', "&quot;")
+        self._file_writeline('<Constant type=\"{}\" value=\"{}\"></Constant>'.format(const.type, const_val))
+
     def visit_orop(self, orop):
         self._file_writeline('<OrOperator>')
         self.indent += self.ind_inc
@@ -30,7 +38,7 @@ class ASTPrinter(TreeWalker):
         orop.right.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</OrOperator>')
-    
+
     def visit_andop(self, andop):
         self._file_writeline('<AndOperator>')
         self.indent += self.ind_inc
@@ -38,7 +46,7 @@ class ASTPrinter(TreeWalker):
         andop.right.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</AndOperator>')
-    
+
     def visit_eqop(self, eqop):
         self._file_writeline('<EqualityOperator op=\"{}\">'.format(eqop.op))
         self.indent += self.ind_inc
@@ -46,7 +54,7 @@ class ASTPrinter(TreeWalker):
         eqop.right.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</EqualityOperator>')
-    
+
     def visit_relop(self, relop):
         self._file_writeline('<RelationalOp op=\"{}\">'.format(relop.op))
         self.indent += self.ind_inc
@@ -54,7 +62,7 @@ class ASTPrinter(TreeWalker):
         relop.right.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</RelationalOp>')
-    
+
     def visit_addop(self, addop):
         self._file_writeline('<AddictiveOp op=\"{}\">'.format(addop.op))
         self.indent += self.ind_inc
@@ -62,7 +70,7 @@ class ASTPrinter(TreeWalker):
         addop.right.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</AddictiveOp>')
-    
+
     def visit_mulop(self, mulop):
         self._file_writeline('<MultiplicativeOp op=\"{}\">'.format(mulop.op))
         self.indent += self.ind_inc
@@ -70,21 +78,21 @@ class ASTPrinter(TreeWalker):
         mulop.right.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</MultiplicativeOp>')
-    
+
     def visit_uop(self, uop):
         self._file_writeline('<UnaryOp op=\"{}\">'.format(uop.op))
         self.indent += self.ind_inc
         uop.operand.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</UnaryOp>')
-    
+
     def visit_decl(self, decl):
         self._file_writeline('<Declaration>')
         self.indent += self.ind_inc
         decl.ident.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</Declaration>')
-    
+
     def visit_assign(self, assign):
         self._file_writeline('<Assign>')
         self.indent += self.ind_inc
@@ -92,7 +100,7 @@ class ASTPrinter(TreeWalker):
         assign.expr.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</Assign>')
-    
+
     def visit_inc(self, inc):
         self._file_writeline('<Increment>')
         self.indent += self.ind_inc
@@ -100,7 +108,7 @@ class ASTPrinter(TreeWalker):
         inc.expr.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</Increment>')
-    
+
     def visit_dec(self, dec):
         self._file_writeline('<Decrement>')
         self.indent += self.ind_inc
@@ -108,11 +116,11 @@ class ASTPrinter(TreeWalker):
         dec.expr.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</Decrement>')
-    
+
     def visit_if(self, if_):
         self._file_writeline('<If>')
         self.indent += self.ind_inc
-        
+
         if_.test.accept(self)
         if if_.block is None:
             self._file_writeline('<Block>')
@@ -125,28 +133,28 @@ class ASTPrinter(TreeWalker):
                 self._file_writeline('</Block>')
             else:
                 branch.accept(self)
-        
+
         self.indent -= self.ind_inc
         self._file_writeline('</If>')
-    
+
     def visit_while(self, while_):
         self._file_writeline('<While>')
         self.indent += self.ind_inc
-        
+
         while_.test.accept(self)
         if while_.block is None:
             self._file_writeline('<Block>')
             self._file_writeline('</Block>')
         else:
             while_.block.accept(self)
-        
+
         self.indent -= self.ind_inc
         self._file_writeline('</While>')
-    
+
     def visit_for(self, for_):
         self._file_writeline('<For>')
         self.indent += self.ind_inc
-        
+
         for_.init.accept(self)
         for_.test.accept(self)
         for_.stmt.accept(self)
@@ -155,55 +163,55 @@ class ASTPrinter(TreeWalker):
             self._file_writeline('</Block>')
         else:
             for_.block.accept(self)
-        
+
         self.indent -= self.ind_inc
         self._file_writeline('</For>')
-    
+
     def visit_dowhile(self, dowhile):
         self._file_writeline('<DoWhile>')
         self.indent += self.ind_inc
-        
+
         if dowhile.block is None:
             self._file_writeline('<Block>')
             self._file_writeline('</Block>')
         else:
             dowhile.block.accept(self)
         dowhile.test.accept(self)
-        
+
         self.indent -= self.ind_inc
         self._file_writeline('</DoWhile>')
-    
+
     def visit_break(self, break_):
         self._file_writeline('<Break></Break>')
-    
+
     def visit_cont(self, cont):
         self._file_writeline('<Continue></Continue>')
-    
+
     def visit_expr(self, expr):
         self._file_writeline('<Expression>')
         self.indent += self.ind_inc
         expr.expr.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</Expression>')
-    
+
     def visit_print(self, print_):
         self._file_writeline('<Print>')
         self.indent += self.ind_inc
         print_.arg.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</Print>')
-    
+
     def visit_scan(self, scan):
         self._file_writeline('<Scan>')
         self.indent += self.ind_inc
         scan.ident.accept(self)
         self.indent -= self.ind_inc
         self._file_writeline('</Scan>')
-    
+
     def visit_blk(self, blk):
         self._file_writeline('<Block>')
         self.indent += self.ind_inc
-        
+
         if blk.prev_blk is None:
             self._file_writeline('<Block>')
             self._file_writeline('</Block>')
@@ -214,22 +222,26 @@ class ASTPrinter(TreeWalker):
             self._file_writeline('</EmptyStatement>')
         else:
             blk.stmt.accept(self)
-        
+
         self.indent -= self.ind_inc
         self._file_writeline('</Block>')
-    
+
     def visit_prgm(self, prgm):
         self._file_writeline('<Program>')
         self.indent += self.ind_inc
-        
+
         if prgm.block is None:
             self._file_writeline('<Block>')
             self._file_writeline('</Block>')
         else:
             prgm.block.accept(self)
-        
+
         self.indent -= self.ind_inc
         self._file_writeline('</Program>')
-    
+
     def _file_writeline(self, line):
         self.file.write(' ' * self.indent + line + '\n')
+
+    def write(self, file_name):
+        with open(file_name + ".ast.xml", "w") as ast:
+            ast.writelines(self.file.lines)


### PR DESCRIPTION
This also gets rid of the dependency on the filename global variable in print_ast by adding a write method which takes an arbitrary filename (eg. if the user wants to write to a specific file). This also fixes writing constants to XML files by escaping all relevant characters, so it's now possible to read the tree with an XML parser (such as xml in python), like so:

```
    import xml.etree.ElementTree as ET
    tree = ET.parse('x.ast.xml')
    print(tree.find("Block").find("Block").find("Print").find("Constant").get("value"))
```